### PR TITLE
Fix CORS error handling

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -1,13 +1,13 @@
 import axios from "axios"; // Requests
-import client from "./index"; // GraphQL requests
-import { ZORA_MEDIA_BY_ID } from "./queries"; // GraphQL Queries
+import client from "data"; // GraphQL requests
+import { ZORA_MEDIA_BY_ID } from "@data/queries"; // GraphQL Queries
 
 /**
  * Collect Zora media post by ID
  * @param {Number} id post number
  * @returns {Object} containing Zora media details
  */
- export const getPostByID = async (id) => {
+export const getPostByID = async (id) => {
   // Collect post
   let post = await client.request(ZORA_MEDIA_BY_ID(id));
   post = post.media;

--- a/data/functions.js
+++ b/data/functions.js
@@ -1,19 +1,27 @@
 import axios from "axios"; // Requests
-import client from "data"; // GraphQL requests
-import { ZORA_MEDIA_BY_ID } from "@data/queries"; // GraphQL Queries
+import client from "./index"; // GraphQL requests
+import { ZORA_MEDIA_BY_ID } from "./queries"; // GraphQL Queries
 
 /**
  * Collect Zora media post by ID
  * @param {Number} id post number
  * @returns {Object} containing Zora media details
  */
-export const getPostByID = async (id) => {
+ export const getPostByID = async (id) => {
   // Collect post
   let post = await client.request(ZORA_MEDIA_BY_ID(id));
   post = post.media;
 
   // Collect post metadata
-  const metadata = await axios.get(post.metadataURI);
+  let metadata = {
+    data: {}
+  };
+  // Post metadata will be null if request fails
+  try {
+    metadata = await axios.get(post.metadataURI);
+  } catch (e) {
+    console.log(e)
+  }
   post.metadata = metadata.data;
 
   // Only show Zora posts


### PR DESCRIPTION
A zNFT was minted on Rinkeby with URIs pointing to google's servers.

The error:
Access to XMLHttpRequest at 'https://storage.googleapis.com/nft-canvas/1/7/metadata.json' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Solution Source:
https://github.com/prisma-labs/graphql-request/blob/master/examples/error-handling.ts